### PR TITLE
Fix environment variable typo in start.pl

### DIFF
--- a/start.pl
+++ b/start.pl
@@ -26,13 +26,13 @@
 package StarterScript;
 
 BEGIN {
-	if ($ENV{BUILDING_WX} == 1 && $^O eq 'MSWin32') {
-		require Wx::Perl::Packager;
-	} elsif ($ENv{BUILDING_WX} == 2 && $^O eq 'MSWin32') {
-		require Tk;
-	} elsif ($ENv{BUILDING_WX} == 3 && $^O eq 'MSWin32') {
-		require Win32::GUI;
-	}
+       if ($ENV{BUILDING_WX} == 1 && $^O eq 'MSWin32') {
+               require Wx::Perl::Packager;
+       } elsif ($ENV{BUILDING_WX} == 2 && $^O eq 'MSWin32') {
+               require Tk;
+       } elsif ($ENV{BUILDING_WX} == 3 && $^O eq 'MSWin32') {
+               require Win32::GUI;
+       }
 }
 
 use strict;


### PR DESCRIPTION
## Summary
- fix typo in environment variable name to ensure correct module loading on Windows

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683fb3fa7aec833083a608790aaafe13