### PR TITLE
Implement otpLocalIP configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ git clone https://github.com/OpenKore/openkore.git
 ```
 
 2. Configure OpenKore: [documentation](https://openkore.com/wiki/Category:control).
+   - Optionally set `otpLocalIP` in `control/config.txt` to specify the IP sent during OTP login. Leave it blank to auto-detect your local IP.
 3. Run openkore.pl _(You can run start.exe or wxstart.exe if you use Windows)_.
 
 ## F.A.Q. (Frequently Asked Questions)

--- a/control/config.txt
+++ b/control/config.txt
@@ -16,6 +16,8 @@ poseidonServer 127.0.0.1
 poseidonPort 24390
 
 bindIp
+# Local IP address sent during OTP login (leave blank for auto-detect)
+otpLocalIP
 forceMapIP
 
 # 1 = hook into RO client, 2 = Act as stand-alone proxy, proxy = act as true proxy

--- a/src/Network/Send.pm
+++ b/src/Network/Send.pm
@@ -31,6 +31,7 @@ use utf8;
 use Carp::Assert;
 use Digest::MD5;
 use Math::BigInt;
+use IO::Socket::INET;
 
 # TODO: remove 'use Globals' from here, instead pass vars on
 use Globals qw(%ai_v %config $bytesSent %packetDescriptions $enc_val1 $enc_val2 $char $masterServer $syncSync $accountID %timeout %talk $skillExchangeItem $net $rodexList $rodexWrite %universalCatalog %rpackets $mergeItemList $repairList %cashShop);
@@ -1453,9 +1454,18 @@ sub sendTokenToServer {
 	my ($self, $username, $password, $master_version, $version, $token, $length, $otp_ip, $otp_port) = @_;
 	my $len =  $length + 92;
 
-	my $password_rijndael = $self->encrypt_password($password);
-	my $ip = '192.168.0.14';
-	my $mac = '20CF3095572A';
+        my $password_rijndael = $self->encrypt_password($password);
+        my $ip = $config{otpLocalIP};
+        unless ($ip) {
+                eval {
+                        my $sock = IO::Socket::INET->new(Proto => 'udp');
+                        $sock->connect('8.8.8.8:53');
+                        $ip = $sock->sockhost;
+                        $sock->close;
+                };
+        }
+        $ip ||= '0.0.0.0';
+        my $mac = '20CF3095572A';
 	my $mac_hyphen_separated = join '-', $mac =~ /(..)/g;
 
 	$net->serverDisconnect();

--- a/src/Network/Send/ROla.pm
+++ b/src/Network/Send/ROla.pm
@@ -5,6 +5,7 @@ use strict;
 use base qw(Network::Send::ServerType0);
 use Globals qw($net %config);
 use Utils qw(getTickCount);
+use IO::Socket::INET;
 
 use Log qw(debug);
 
@@ -123,7 +124,16 @@ sub sendTokenToServer {
     my ($self, $username, $password, $master_version, $version, $token, $length, $otp_ip, $otp_port) = @_;
     my $len = $length + 92;
 
-    my $ip = '192.168.0.2';
+    my $ip = $config{otpLocalIP};
+    unless ($ip) {
+        eval {
+            my $sock = IO::Socket::INET->new(Proto => 'udp');
+            $sock->connect('8.8.8.8:53');
+            $ip = $sock->sockhost;
+            $sock->close;
+        };
+    }
+    $ip ||= '0.0.0.0';
     my $mac = $config{macAddress} || sprintf("%02x%02x%02x%02x%02x%02x", (int(rand(256)) & 0xFC) | 0x02, map { int(rand(256)) } 1..5);
     my $mac_hyphen_separated = join '-', $mac =~ /(..)/g;
 

--- a/tables/bRO/control-br/config.txt
+++ b/tables/bRO/control-br/config.txt
@@ -29,6 +29,8 @@ poseidonServer 127.0.0.1
 poseidonPort 24390
 
 bindIp
+# Endereço IP local enviado durante o login OTP (deixe em branco para detectar automaticamente)
+otpLocalIP
 forceMapIP
 
 # 1 = rodar dentro do cliente do RO, 2 = usar proxy autônomo, proxy = atua como proxy verdadeiro

--- a/tables/twRO/chinese/control/config.txt
+++ b/tables/twRO/chinese/control/config.txt
@@ -31,6 +31,8 @@ char
 # 命令"charselect 1" 回到角色選擇畫面會清除角色編號
 bindIp
 # 如果您的電腦有多個 IP 地址，你可以選擇要使用哪一個 要是您不確定，這個選項您應該保留空白。
+otpLocalIP
+# OTP 登入時使用的本地 IP (留空自動偵測)
 forceMapIP
 # 指定地圖伺服器IP [ twRO 請留空 ]
 


### PR DESCRIPTION
## Summary
- add `otpLocalIP` option to configuration samples
- auto-detect local IP in `sendTokenToServer`
- mention the option in README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684b11380c7c8330bcf02acc708aaa03